### PR TITLE
Potential fix for code scanning alert no. 9: Reflected cross-site scripting

### DIFF
--- a/src/app/callback/auth-code/route.ts
+++ b/src/app/callback/auth-code/route.ts
@@ -1,7 +1,18 @@
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 export async function GET(request: Request) {
 	const url = new URL(request.url);
 	const code = url.searchParams.get('code') || '';
 	const state = url.searchParams.get('state') || '';
+	const safeCode = code ? escapeHtml(code.slice(0, 8) + '…') : '(none)';
+	const safeState = state ? escapeHtml(state) : '(none)';
 	const html = `<!DOCTYPE html>
 	<html lang="en">
 	<head>
@@ -17,7 +28,7 @@ export async function GET(request: Request) {
 	<body>
 		<h1>Processing sign-in…</h1>
 		<p class="muted">If this window does not close automatically, you can close it.</p>
-		<p class="muted">code: <code>${code ? code.slice(0, 8) + '…' : '(none)'}</code>, state: <code>${state || '(none)'}</code></p>
+		<p class="muted">code: <code>${safeCode}</code>, state: <code>${safeState}</code></p>
 		<script>
 			(function(){
 				try {


### PR DESCRIPTION
Potential fix for [https://github.com/edipal/entra-oauth-playground/security/code-scanning/9](https://github.com/edipal/entra-oauth-playground/security/code-scanning/9)

In general, to fix reflected XSS when embedding user-controlled data into HTML, you must apply *context-appropriate output encoding* before inserting the data into the HTML string. For plain text inside HTML element content (like the text inside `<code>...</code>`), HTML-escaping is sufficient: characters such as `<`, `>`, `&`, `"`, and `'` should be converted to their HTML entity equivalents. This prevents the browser from interpreting the inserted text as markup or script.

The best minimal fix here, without changing existing functionality, is:

- Introduce a small HTML-escaping helper in this file.
- Use it to escape `code` (the truncated version) and `state` before interpolating them into the template literal.
- Keep the rest of the response and behavior unchanged.

Concrete changes in `src/app/callback/auth-code/route.ts`:

1. Add a local `escapeHtml` function near the top of the file (before `GET`) that replaces `&`, `<`, `>`, `"`, and `'` with their respective HTML entities.
2. In the `GET` function, compute:
   - `const safeCode = code ? escapeHtml(code.slice(0, 8) + '…') : '(none)';`
   - `const safeState = state ? escapeHtml(state) : '(none)';`
3. Update the HTML template to use `${safeCode}` and `${safeState}` instead of interpolating `code.slice(...)` and `state` directly.

No external libraries are strictly needed; a small, well-known escaping implementation is enough, and we keep all changes confined to this file and the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
