### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/src/components/steps/StepValidate.tsx
+++ b/src/components/steps/StepValidate.tsx
@@ -197,7 +197,11 @@ export default function StepValidate(props: Props) {
         if (skipGraph) { setAccSig({}); return; }
         let jwksUrl = '';
         const host = (() => { try { return new URL(accIss!).host.toLowerCase(); } catch { return ''; } })();
-        if (host.includes('login.microsoftonline.com') || host.includes('sts.windows.net')) {
+        const microsoftHosts = new Set([
+          'login.microsoftonline.com',
+          'sts.windows.net',
+        ]);
+        if (host && microsoftHosts.has(host)) {
           // Try v2 then v1
           const tenant = (accessPayload.tid || 'common').trim();
           const candidates = [


### PR DESCRIPTION
Potential fix for [https://github.com/edipal/entra-oauth-playground/security/code-scanning/6](https://github.com/edipal/entra-oauth-playground/security/code-scanning/6)

In general, to fix incomplete URL substring sanitization when checking hosts, you should avoid `includes`, `indexOf`, or regexes that allow arbitrary prefixes/suffixes, and instead compare against an explicit whitelist of allowed hostnames (or a rigorously constrained pattern). In this case, `host` is already parsed via `new URL(accIss!).host`, so we only need to replace the substring tests with explicit equality against the known Microsoft hostnames.

The best fix here is to normalize `host` to lowercase (already done) and then check whether it is exactly one of the expected Microsoft hosts, e.g. `login.microsoftonline.com` or `sts.windows.net`. If there are known regional variants that should also be treated as Microsoft (such as `login.microsoftonline.de` or `login.partner.microsoftonline.cn`), they can be added explicitly to the allowed‑host set. This preserves the existing logic (treating Microsoft issuers specially) but prevents hosts that merely contain those strings from being misclassified.

Concretely, in `src/components/steps/StepValidate.tsx` around line 199–201, replace:

```ts
const host = (() => { try { return new URL(accIss!).host.toLowerCase(); } catch { return ''; } })();
if (host.includes('login.microsoftonline.com') || host.includes('sts.windows.net')) {
```

with code that uses strict comparison against a small whitelist, for example:

```ts
const host = (() => { try { return new URL(accIss!).host.toLowerCase(); } catch { return ''; } })();
const microsoftHosts = new Set([
  'login.microsoftonline.com',
  'sts.windows.net',
]);
if (host && microsoftHosts.has(host)) {
```

No new imports are required; `Set` and `URL` are standard. The behavior remains the same for legitimate Microsoft issuer URLs, but a malicious issuer hostname that only embeds `login.microsoftonline.com` or `sts.windows.net` as a substring will no longer be treated as Microsoft.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
