### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/jwtVerify.ts
+++ b/src/lib/jwtVerify.ts
@@ -29,7 +29,12 @@ export const guessJwksUrl = (iss?: string, tid?: string, ver?: string) => {
     const host = u.host.toLowerCase();
     const tenant = (tid || 'common').trim();
     const v = (ver || (iss.includes('/v2.0') ? '2.0' : '1.0')).startsWith('2') ? 'v2.0' : 'v1.0';
-    if (host.includes('login.microsoftonline.com') || host.includes('sts.windows.net')) {
+    const isAllowedHost = (h: string, domain: string) =>
+      h === domain || h.endsWith('.' + domain);
+    if (
+      isAllowedHost(host, 'login.microsoftonline.com') ||
+      isAllowedHost(host, 'sts.windows.net')
+    ) {
       return `https://login.microsoftonline.com/${tenant}/discovery/v2.0/keys`;
     }
   } catch {}


### PR DESCRIPTION
Potential fix for [https://github.com/edipal/entra-oauth-playground/security/code-scanning/2](https://github.com/edipal/entra-oauth-playground/security/code-scanning/2)

In general, to fix this issue we should avoid checking trusted hosts using `includes` on the host string. Instead, we should either (a) compare the host to a whitelist of exact allowed hostnames, or (b) verify that the host is either exactly the trusted domain or is a subdomain of it (using proper dot-boundary checks, not simple substring checks). Since the existing code already parses `iss` with `new URL(iss)` and extracts `host`, we just need to replace `host.includes('login.microsoftonline.com')` and `host.includes('sts.windows.net')` with robust checks that preserve current intent.

The single best way here, without changing exposed functionality, is to define a small helper inside `guessJwksUrl` that determines whether a host is either exactly an allowed domain or a subdomain of it. For example:

```ts
const isAllowedHost = (host: string, domain: string) =>
  host === domain || host.endsWith('.' + domain);
```

We then replace the `if` condition on line 32 with a combination of these checks:

```ts
if (isAllowedHost(host, 'login.microsoftonline.com') || isAllowedHost(host, 'sts.windows.net')) {
  ...
}
```

This ensures that hosts like `login.microsoftonline.com` and `foo.login.microsoftonline.com` are allowed, but `evil-login.microsoftonline.com` or `sts.windows.net.evil.com` are not. All changes are confined to the `guessJwksUrl` function in `src/lib/jwtVerify.ts`, and no new imports are needed because we only add a local helper function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
